### PR TITLE
Add support of Print Preview URL parameter

### DIFF
--- a/app.css
+++ b/app.css
@@ -2089,6 +2089,67 @@ left:-5000px;
 	}
 }
 
+/* Emulate @media print styles */
+
+body.print-preview {
+	
+	.hidden-print {
+		display: none !important;
+	}
+
+	#app-container{
+		width: 100% !important;
+		padding: 0px !important;
+		margin-left: 0% !important;
+		margin-right: 0% !important;
+	}
+
+	.notation-holder{
+		display: inline-block !important;
+		text-align: center !important;
+		margin-bottom:0px !important;
+		width:97% !important;
+		margin-left: 3% !important;
+		margin-right: 0% !important;
+		position:static !important;
+		left: 0% !important;
+		right: 0% !important;
+		flex-flow: unset !important;
+	}
+
+	.relativebox {
+		position:static !important;
+		float:none !important;
+		flex-flow:unset !important;
+	}
+
+	.pagebreak { 
+		page-break-after:always !important; 
+		width:97% !important;
+		margin-left: 1% !important;
+		margin-right: 0% !important;
+		position:static !important;
+		display: block !important;
+		flex-flow: unset;
+	} 
+
+	.modal_flat_background{
+		display:none !important;
+	}
+
+	.modal_flat_main{
+		display:none !important;
+	}
+
+	.modal_flat_wide_background{
+		display:none !important;
+	}
+
+	.modal_flat_wide_main{
+		display:none !important;
+	}
+}
+
 @media print {
   	.hidden-print {
     display: none !important;

--- a/app.js
+++ b/app.js
@@ -21827,6 +21827,16 @@ function processShareLink() {
 		}
 	}
 
+	// Open in print preview mode with GUI disabled
+
+	if (urlParams.has("ppw")) {
+
+		const body = document.querySelector('body');
+
+		if (body.classList.contains("print preview")) return;
+
+		body.classList.add("print-preview");
+	}
 
 	// If multiple tunes in the link, which one to open in the player?
 	var gotIndex = false;


### PR DESCRIPTION
+ Adds CSS rule `body.print-preview` emulating `@media print` adjustments
+ Adds `&ppw` to the list of supported URL params in `app.js` > `processShareLink()`
+ When `&ppw` is detected in a share link, body.print-preview rule is applied
+ Allows for instant and simple disabling of GUI when working with ABCs
+ Makes the displayed notes block fully responsive in browsers
+ Enables flexible resizing of ABC Tools iframe in exported websites (a "view-only" mode)