### PR TITLE
Fix for long-tap playback action firing on scroll

### DIFF
--- a/abctools.html
+++ b/abctools.html
@@ -241,7 +241,7 @@
 	<script type="text/javascript" src="website_generator.js"></script><!-- Generate website -->	
 	<script type="text/javascript" src="pdf-website-import.js"></script><!-- PDF and website import -->	
 	<script type="text/javascript" src="context-menu.js"></script><!-- Dropdown context menus -->	
-	<script type="text/javascript" src="app-min.js"></script><!-- main application business logic -->
+	<script type="text/javascript" src="app.js"></script><!-- main application business logic -->
 	<script type="text/javascript" src="api-keys.js"></script><!-- API keys used by the tool -->
 
 </html>

--- a/abctools.html
+++ b/abctools.html
@@ -241,7 +241,7 @@
 	<script type="text/javascript" src="website_generator.js"></script><!-- Generate website -->	
 	<script type="text/javascript" src="pdf-website-import.js"></script><!-- PDF and website import -->	
 	<script type="text/javascript" src="context-menu.js"></script><!-- Dropdown context menus -->	
-	<script type="text/javascript" src="app.js"></script><!-- main application business logic -->
+	<script type="text/javascript" src="app-min.js"></script><!-- main application business logic -->
 	<script type="text/javascript" src="api-keys.js"></script><!-- API keys used by the tool -->
 
 </html>

--- a/app.js
+++ b/app.js
@@ -493,7 +493,7 @@ function SetupEmbeddedMobileEventHanders(el){
 
 	touchEventsToCancel.forEach(touchEvent => {
 
-		el.addEventListener(touchEvent => {
+		el.addEventListener(touchEvent, (e) => {
 
 			clearTimeout(gUIEmbeddedPressTimer);
 	

--- a/app.js
+++ b/app.js
@@ -489,22 +489,23 @@ function SetupEmbeddedMobileEventHanders(el){
 		}, gUIEmbeddedPressTimerDelay); 
 	});
 
-	el.addEventListener('touchend', (e) => {
+	const touchEventsToCancel = ['touchend', 'touchmove', 'touchcancel'];
 
-		clearTimeout(gUIEmbeddedPressTimer);
+	touchEventsToCancel.forEach(touchEvent => {
 
-		gUIEmbeddedPressTimer = null;
+		el.addEventListener(touchEvent => {
 
+			clearTimeout(gUIEmbeddedPressTimer);
+	
+			gUIEmbeddedPressTimer = null;
+	
+		});
 	});
 
-	el.addEventListener('touchcancel', (e) => {
+	el.addEventListener('contextmenu', (e) => {
 
-		clearTimeout(gUIEmbeddedPressTimer);
-
-		gUIEmbeddedPressTimer = null;
-
+		e.preventDefault();
 	});
-
 }
 
 


### PR DESCRIPTION
+ Added 'touchmove' events responsible for scrolling and dragging to the list of events to listen to and clearTimeout if detected (supported by all browsers except Safari where it's currently in "technology preview" phase)
+ Optionally preventing 'contextmenu' events